### PR TITLE
Add libzmq version checking to installer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,32 +4,15 @@
 pyczmq
 ======
 """
-from cffi import FFI
+from pyczmq.zmq import version as zmq_version
 from setuptools import setup, find_packages
 import sys
 
-ffi = FFI()
-Z = ffi.dlopen('zmq')
-C = ffi.dlopen('czmq')
 
-ffi.cdef('void zmq_version (int *major, int *minor, int *patch);')
-
-def zmq_version(lib):
-    """
-    Returns the tuple (major, minor, patch) of the current libzmq version.
-    """
-    major = ffi.new('int*')
-    minor= ffi.new('int*')
-    patch = ffi.new('int*')
-    Z.zmq_version(major, minor, patch)
-    return (major[0], minor[0], patch[0])
-
-zmq_version = zmq_version(Z)
-
-
-if zmq_version < (4,0,0):
+if zmq_version() < (4,0,0):
     print "ERROR: pyczmq requires libzmq 4.0.0 or later."
     sys.exit(1)
+
 
 setup(
   name="pyczmq",


### PR DESCRIPTION
This should go some way to resolving the issue raised in #14. Once CZMQ supports runtime version checking then CZMQ version can be added to the check.
