### PR TITLE
Run Pypy & Python 3 tests in "allow_failures" mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,15 @@
 language: python
 
 python:
-  - "2.6"
+  - "2.6"  # can we drop Python 2.6??  https://docs.python.org/devguide/index.html#branchstatus
   - "2.7"
-#  - "3.2"  # requires some additonal (str) work for compatibility
-#  - "3.3"  # requires some additonal (str) work for compatibility
-#  - "pypy" # investigate why ffi.from_handle is causing issues
+  - "3.6"  # requires some additonal (str) work for compatibility
+  - "pypy" # investigate why ffi.from_handle is causing issues
+
+matrix:
+  allow_failures:
+    - python: "3.6"
+    - python: "pypy"
 
 # Perform regression test build against latest dependencies
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@
 language: python
 
 python:
-  - "2.6"  # can we drop Python 2.6??  https://docs.python.org/devguide/index.html#branchstatus
   - "2.7"
   - "3.6"  # requires some additonal (str) work for compatibility
   - "pypy" # investigate why ffi.from_handle is causing issues
@@ -59,4 +58,3 @@ install:
 # Test and install PYCZMQ
 script:
   - nosetests
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
 
 before_install: 
   # Install Python dependencies
-  - pip install --use-mirrors -r requirements.txt
+  - pip install -r requirements.txt
 
   # Install C library dependencies
 


### PR DESCRIPTION
In allow_failures mode, they will not halt the build but contributors can see where tests are failing.

Can we drop Python 2.6 support?  It went EOL in 2013!  https://docs.python.org/devguide/index.html#branchstatus